### PR TITLE
Change generation settings to be blank

### DIFF
--- a/Coverup/control.lua
+++ b/Coverup/control.lua
@@ -29,7 +29,10 @@ local function RemoveOres(surface, x, y)
     else
       local surface2 = game.surfaces[surface.name.."__hiddenores__"]
       if not surface2 then
-        surface2 = game.create_surface(surface.name.."__hiddenores__")
+        local gen_settings = {water=0,
+          default_enable_all_autoplace_controls=false
+          }
+        surface2 = game.create_surface(surface.name.."__hiddenores__", gen_settings)
       end
       for _,res in pairs(ents) do
         if IsCovered(res, surface, radius) then


### PR DESCRIPTION
Currently, functionality relies on the hidden surface not being generated. If the surface is generated -- through the editor, for example -- water and other ores may be present, preventing saving of ores or allowing other ores to be created. Change generation to not generate water, entities, or decoratives. Cliffs are still generated but are removed when ores are added to the hidden surface.